### PR TITLE
fix: configure SendGrid for bug reports using GitHub Secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -265,6 +265,7 @@ jobs:
           --platform managed \
           --allow-unauthenticated \
           --env-vars-file ${{ steps.config.outputs.env_file }} \
+          --update-env-vars SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }} \
           --add-cloudsql-instances home-game-472415:us-central1:home-game-db \
           --memory 1Gi \
           --cpu 1 \
@@ -294,6 +295,7 @@ jobs:
           --region us-central1 \
           --set-cloudsql-instances home-game-472415:us-central1:home-game-db \
           --env-vars-file ${{ steps.config.outputs.env_file }} \
+          --update-env-vars SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }} \
           --execute-now \
           --wait \
           --command="python" \

--- a/backend/cloud-run-env-staging.yaml
+++ b/backend/cloud-run-env-staging.yaml
@@ -3,9 +3,11 @@ USE_DOMAIN_SERVICES: "true"
 ALLOWED_ORIGINS: http://localhost:3001,http://localhost:3000,https://home-game-ntmeec97f-edunbars-projects.vercel.app,https://staging.homegame.gg,https://home-game-staging.vercel.app
 # Use same Cloud SQL instance but different database
 DATABASE_URL: postgresql+psycopg2://poker_user:O1XbT66.^#H!83[fds234@/home_game_staging?host=/cloudsql/home-game-472415:us-central1:home-game-db
+# SENDGRID_API_KEY is injected from GitHub Secrets during deployment
+FROM_EMAIL: noreply@homegame.gg
+BUG_REPORT_EMAIL: help@homegame.gg
 MAIL_SERVER: smtp.gmail.com
 MAIL_PORT: "587"
 MAIL_USE_TLS: "true"
 MAIL_USERNAME: REPLACE_WITH_YOUR_GMAIL@gmail.com
 MAIL_PASSWORD: REPLACE_WITH_YOUR_APP_PASSWORD
-BUG_REPORT_EMAIL: REPLACE_WITH_YOUR_EMAIL@gmail.com

--- a/backend/cloud-run-env.yaml
+++ b/backend/cloud-run-env.yaml
@@ -1,9 +1,11 @@
 FLASK_ENV: production
 ALLOWED_ORIGINS: https://homegame.gg,https://www.homegame.gg,https://home-game-8iqzfr8tg-edunbars-projects.vercel.app
 DATABASE_URL: postgresql+psycopg2://poker_user:O1XbT66.^#H!83[fds234@/home_game?host=/cloudsql/home-game-472415:us-central1:home-game-db
+# SENDGRID_API_KEY is injected from GitHub Secrets during deployment
+FROM_EMAIL: noreply@homegame.gg
+BUG_REPORT_EMAIL: help@homegame.gg
 MAIL_SERVER: smtp.gmail.com
 MAIL_PORT: "587"
 MAIL_USE_TLS: "true"
 MAIL_USERNAME: REPLACE_WITH_YOUR_GMAIL@gmail.com
 MAIL_PASSWORD: REPLACE_WITH_YOUR_APP_PASSWORD
-BUG_REPORT_EMAIL: REPLACE_WITH_YOUR_EMAIL@gmail.com


### PR DESCRIPTION
- Add FROM_EMAIL and BUG_REPORT_EMAIL to cloud-run-env files
- Update deployment workflow to inject SENDGRID_API_KEY from GitHub Secrets
- Fixes "SendGrid API key missing" error on production bug reports

Security: API key stored in GitHub Secrets, not in repository