### PR TITLE
fix: separate env var injection from gcloud deploy command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -265,7 +265,6 @@ jobs:
           --platform managed \
           --allow-unauthenticated \
           --env-vars-file ${{ steps.config.outputs.env_file }} \
-          --update-env-vars SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }} \
           --add-cloudsql-instances home-game-472415:us-central1:home-game-db \
           --memory 1Gi \
           --cpu 1 \
@@ -274,6 +273,13 @@ jobs:
           --timeout 300
 
         echo "✅ Cloud Run deployment complete!"
+
+        echo "🔑 Injecting SENDGRID_API_KEY from GitHub Secrets..."
+        gcloud run services update ${{ steps.config.outputs.service_name }} \
+          --region us-central1 \
+          --update-env-vars SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }}
+
+        echo "✅ Environment variables updated!"
 
     - name: Run database migrations
       if: needs.pre-deploy-checks.outputs.has_migrations == 'true'
@@ -295,7 +301,6 @@ jobs:
           --region us-central1 \
           --set-cloudsql-instances home-game-472415:us-central1:home-game-db \
           --env-vars-file ${{ steps.config.outputs.env_file }} \
-          --update-env-vars SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }} \
           --execute-now \
           --wait \
           --command="python" \


### PR DESCRIPTION
- Remove --update-env-vars flag from gcloud run deploy (conflicts with --env-vars-file)
- Add separate gcloud run services update step to inject SENDGRID_API_KEY
- Remove --update-env-vars from migration job (doesn't need SendGrid key)
- Fixes 'At most one of --env-vars-file | --update-env-vars can be specified' error