### PR TITLE
fix: make external_id matching case-insensitive to prevent duplicate players

### DIFF
--- a/backend/merge_duplicate_players.py
+++ b/backend/merge_duplicate_players.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+Merge Duplicate Players Script
+
+Finds and merges duplicate players (same display name, case-insensitive) within games.
+This happens when:
+- PokerNow returns different capitalization for external_id (e.g., "lw0lJXpCtc" vs "lw0lJXpCtC")
+- Same player joins as guest instead of logged-in account (different external_ids)
+- Case-sensitive matching creates unnecessary duplicates
+
+The script automatically:
+1. Groups players by display name (case-insensitive) within each game
+2. Selects the "keeper" (player with most sessions, or earliest created if tied)
+3. Merges all other duplicates into the keeper
+4. Preserves all session data and payment history
+
+Usage:
+    # Dry run (shows what would be merged, no changes)
+    PYTHONPATH=src python merge_duplicate_players.py --dry-run
+
+    # Fix specific game
+    PYTHONPATH=src python merge_duplicate_players.py --game-code C4QRO
+
+    # Fix all games
+    PYTHONPATH=src python merge_duplicate_players.py
+"""
+
+import argparse
+import sys
+from collections import defaultdict
+from datetime import datetime
+from typing import List, Dict, Optional, Tuple
+
+from sqlalchemy import func
+from db.database import SessionLocal
+from db.models import Game, Player, SessionPlayerSummary, Session
+from services.player_merge_service_v2 import PlayerMergeServiceV2
+
+
+def find_duplicates_in_game(db, game_id: str) -> Dict[str, List[Dict]]:
+    """
+    Find duplicate players (same display name) in a game.
+
+    Returns:
+        Dictionary mapping normalized display name to list of player records:
+        {
+            'remy': [
+                {'id': '...', 'display_name': 'Remy', 'external_id': '...', 'num_sessions': 23, ...},
+                {'id': '...', 'display_name': 'REMY', 'external_id': '...', 'num_sessions': 1, ...}
+            ]
+        }
+    """
+    # Query all players in this game with session counts
+    players_query = (
+        db.query(
+            Player.id,
+            Player.display_name,
+            Player.external_id,
+            Player.created_at,
+            func.count(SessionPlayerSummary.session_id).label('num_sessions')
+        )
+        .join(SessionPlayerSummary, Player.id == SessionPlayerSummary.player_id)
+        .join(Session, SessionPlayerSummary.session_id == Session.id)
+        .filter(Session.game_id == game_id)
+        .group_by(Player.id, Player.display_name, Player.external_id, Player.created_at)
+        .order_by(Player.display_name, Player.created_at)
+        .all()
+    )
+
+    # Group by normalized display name
+    groups = defaultdict(list)
+    for player in players_query:
+        normalized_name = player.display_name.lower().strip()
+        groups[normalized_name].append({
+            'id': str(player.id),
+            'display_name': player.display_name,
+            'external_id': player.external_id,
+            'created_at': player.created_at,
+            'num_sessions': player.num_sessions
+        })
+
+    # Filter to only groups with duplicates (count > 1)
+    duplicates = {name: players for name, players in groups.items() if len(players) > 1}
+
+    return duplicates
+
+
+def select_keeper_and_sources(duplicates: List[Dict]) -> Tuple[Dict, List[Dict]]:
+    """
+    Select which player to keep and which to merge.
+
+    Strategy:
+    - Keep player with most sessions
+    - If tied, keep earliest created
+    - Merge all others into keeper
+
+    Returns:
+        (keeper_player, source_players_list)
+    """
+    # Sort by: num_sessions DESC, created_at ASC
+    sorted_players = sorted(
+        duplicates,
+        key=lambda p: (-p['num_sessions'], p['created_at'])
+    )
+
+    keeper = sorted_players[0]
+    sources = sorted_players[1:]
+
+    return keeper, sources
+
+
+def merge_duplicate_players(game_code: Optional[str] = None, dry_run: bool = True):
+    """
+    Find and merge duplicate players in games.
+
+    Args:
+        game_code: If provided, only process this game. Otherwise process all games.
+        dry_run: If True, only show what would be merged without making changes.
+    """
+    with SessionLocal() as db:
+        # Get games to process
+        if game_code:
+            games = db.query(Game).filter(Game.public_code == game_code).all()
+            if not games:
+                print(f"ERROR: Game with code '{game_code}' not found")
+                return
+        else:
+            games = db.query(Game).all()
+
+        print(f"\n{'='*80}")
+        print(f"Mode: {'DRY RUN (no changes will be made)' if dry_run else 'LIVE MERGE'}")
+        print(f"Games to process: {len(games)}")
+        print(f"{'='*80}\n")
+
+        total_duplicate_sets = 0
+        total_merges = 0
+
+        for game in games:
+            print(f"\nProcessing game: {game.title or game.public_code} ({game.public_code})")
+            print(f"-" * 80)
+
+            # Find duplicates in this game
+            duplicates = find_duplicates_in_game(db, game.id)
+
+            if not duplicates:
+                print("  No duplicate players found")
+                continue
+
+            print(f"  Found {len(duplicates)} duplicate set(s):\n")
+            total_duplicate_sets += len(duplicates)
+
+            for name, players in duplicates.items():
+                # Select keeper and sources
+                keeper, sources = select_keeper_and_sources(players)
+
+                print(f"  Duplicate set: \"{keeper['display_name']}\" ({len(players)} players)")
+                print(f"    KEEP:   {keeper['id'][:8]} (external_id: {keeper['external_id']}) - {keeper['num_sessions']} sessions, created {keeper['created_at']}")
+
+                for source in sources:
+                    print(f"    MERGE:  {source['id'][:8]} (external_id: {source['external_id']}) - {source['num_sessions']} sessions, created {source['created_at']}")
+
+                print(f"    Action: Merge {sum(s['num_sessions'] for s in sources)} session(s) into keeper")
+
+                if not dry_run:
+                    # Execute merge
+                    try:
+                        # Determine external_id to use:
+                        # - If all players have EXACTLY the same external_id (case-sensitive), use it
+                        # - Otherwise, pass None and let merge service handle it (will keep keeper's)
+                        all_external_ids = [keeper['external_id']] + [s['external_id'] for s in sources if s['external_id']]
+                        unique_external_ids = set(eid for eid in all_external_ids if eid)
+
+                        if len(unique_external_ids) == 1:
+                            # All exactly the same - safe to use
+                            merge_external_id = keeper['external_id']
+                        else:
+                            # Different external_ids (including case-only differences)
+                            # Pass None so merge service doesn't validate, keeper's will be inherited
+                            merge_external_id = None
+                            if len(unique_external_ids) > 1:
+                                print(f"    Note: Different external_ids detected, keeper's will be used")
+
+                        merge_service = PlayerMergeServiceV2(db)
+                        result = merge_service.merge_players(
+                            target_player_id=keeper['id'],
+                            source_player_ids=[s['id'] for s in sources],
+                            verified_name=keeper['display_name'],
+                            external_id=merge_external_id,
+                            game_id=str(game.id)
+                        )
+                        print(f"    ✓ Successfully merged {len(sources)} player(s)")
+                        total_merges += len(sources)
+                        db.commit()
+                    except Exception as e:
+                        print(f"    ✗ ERROR: Failed to merge: {e}")
+                        db.rollback()
+                else:
+                    print(f"    ✓ Would merge {len(sources)} player(s) (dry run)")
+                    total_merges += len(sources)
+
+                print()
+
+        print(f"\n{'='*80}")
+        print(f"Summary:")
+        print(f"  Duplicate sets found: {total_duplicate_sets}")
+        print(f"  Players {'merged' if not dry_run else 'to merge'}: {total_merges}")
+        if dry_run:
+            print(f"\n  NOTE: This was a dry run. No changes were made.")
+            print(f"        Run without --dry-run to apply changes.")
+        print(f"{'='*80}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Merge duplicate players (same display name) within games'
+    )
+    parser.add_argument(
+        '--game-code',
+        type=str,
+        help='Only process this specific game code (e.g., C4QRO)'
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        default=False,
+        help='Show what would be merged without making changes'
+    )
+
+    args = parser.parse_args()
+
+    try:
+        merge_duplicate_players(
+            game_code=args.game_code,
+            dry_run=args.dry_run
+        )
+    except Exception as e:
+        print(f"\nERROR: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/src/infrastructure/persistence/sqlalchemy/player_repository.py
+++ b/backend/src/infrastructure/persistence/sqlalchemy/player_repository.py
@@ -77,10 +77,11 @@ class SQLAlchemyPlayerRepository(PlayerRepository):
         external_id: ExternalId,
         exclude_player_id: Optional[PlayerId] = None
     ) -> bool:
-        """Check if an external ID is already in use."""
+        """Check if an external ID is already in use (case-insensitive)."""
         try:
+            from sqlalchemy import func
             query = self._db_session.query(PlayerModel).filter(
-                PlayerModel.external_id == external_id.value
+                func.lower(PlayerModel.external_id) == func.lower(external_id.value)
             )
 
             if exclude_player_id:
@@ -226,6 +227,46 @@ class SQLAlchemyPlayerRepository(PlayerRepository):
                     else:
                         # Move link
                         link.player_id = target_model.id
+
+                # Update PlayerHandParticipation records (hand analytics)
+                from db.models import PlayerHandParticipation, PlayerStatisticsCache
+                hand_participations = self._db_session.query(PlayerHandParticipation).filter(
+                    PlayerHandParticipation.player_id == source_model.id
+                ).all()
+
+                for participation in hand_participations:
+                    # Check if target already has participation for this session+hand (duplicate data)
+                    existing_participation = self._db_session.query(PlayerHandParticipation).filter(
+                        PlayerHandParticipation.session_id == participation.session_id,
+                        PlayerHandParticipation.player_id == target_model.id,
+                        PlayerHandParticipation.hand_number == participation.hand_number
+                    ).first()
+
+                    if existing_participation:
+                        # Delete duplicate participation (same person recorded twice)
+                        self._db_session.delete(participation)
+                    else:
+                        # Move to target player
+                        participation.player_id = target_model.id
+
+                # Update PlayerStatisticsCache records
+                stats_cache = self._db_session.query(PlayerStatisticsCache).filter(
+                    PlayerStatisticsCache.player_id == source_model.id
+                ).all()
+
+                for stats in stats_cache:
+                    # Check if target already has stats for this session
+                    existing_stats = self._db_session.query(PlayerStatisticsCache).filter(
+                        PlayerStatisticsCache.session_id == stats.session_id,
+                        PlayerStatisticsCache.player_id == target_model.id
+                    ).first()
+
+                    if existing_stats:
+                        # Delete duplicate (keep target's stats, they should be the same player)
+                        self._db_session.delete(stats)
+                    else:
+                        # Move to target
+                        stats.player_id = target_model.id
 
                 # Delete source player
                 self._db_session.delete(source_model)

--- a/backend/src/services/player_merge_service_v2.py
+++ b/backend/src/services/player_merge_service_v2.py
@@ -162,9 +162,9 @@ class PlayerMergeServiceV2:
                     domain_external_id,
                     exclude_player_id=domain_target_id
                 ):
-                    # Check if it's from one of the source players
+                    # Check if it's from one of the source players (case-insensitive)
                     has_match = any(
-                        p.external_id == domain_external_id
+                        p.external_id and p.external_id.value.lower() == domain_external_id.value.lower()
                         for p in source_players
                     )
                     if not has_match:

--- a/backend/src/services/session_ingestion_service.py
+++ b/backend/src/services/session_ingestion_service.py
@@ -192,8 +192,8 @@ def _upsert_db_for_session(
         display_name = (p.get("validated_name") or (p.get("names")[0] if p.get("names") else "Unknown")).strip()
 
         # Create a unique key based on external_id or normalized display_name
-        # external_id is case-sensitive, display_name is case-insensitive
-        unique_key = ext_pid if ext_pid else display_name.lower()
+        # Both external_id and display_name are normalized to lowercase for case-insensitive matching
+        unique_key = ext_pid.lower() if ext_pid else display_name.lower()
 
         if unique_key not in seen_players:
             seen_players.add(unique_key)
@@ -210,10 +210,11 @@ def _upsert_db_for_session(
         player = None
 
         # FIRST: If external_id exists, search globally (external_id is unique across all games)
+        # Use case-insensitive matching to handle PokerNow's capitalization inconsistencies
         if ext_pid:
             player = db.execute(
                 select(Player)
-                .where(Player.external_id == ext_pid)
+                .where(func.lower(Player.external_id) == ext_pid.lower())
             ).scalar_one_or_none()
 
         # SECOND: Only if no external_id match found, try display_name within this game
@@ -231,8 +232,9 @@ def _upsert_db_for_session(
                 player = players[0]
             elif len(players) > 1:
                 # Multiple players with same display name - pick the one with matching external_id if available
+                # Use case-insensitive matching to handle PokerNow's capitalization inconsistencies
                 if ext_pid:
-                    player = next((p for p in players if p.external_id and p.external_id == ext_pid), players[0])
+                    player = next((p for p in players if p.external_id and p.external_id.lower() == ext_pid.lower()), players[0])
                 else:
                     player = players[0]
 
@@ -249,11 +251,11 @@ def _upsert_db_for_session(
             # Handle external_id updates carefully
             if ext_pid and not player.external_id:
                 # Player found by name but has no external_id
-                # Check if this external_id is already taken by another player
+                # Check if this external_id is already taken by another player (case-insensitive)
                 existing_player_with_id = db.execute(
                     select(Player)
                     .where(
-                        Player.external_id == ext_pid,
+                        func.lower(Player.external_id) == ext_pid.lower(),
                         Player.id != player.id
                     )
                 ).scalar_one_or_none()

--- a/backend/test_merge_duplicates.py
+++ b/backend/test_merge_duplicates.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Test script for merge_duplicate_players.py
+
+Creates test data with duplicate players and verifies the merge script works.
+"""
+
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+from db.database import SessionLocal
+from db.models import Game, Player, Session, SessionPlayerSummary
+
+def create_test_data():
+    """Create test game with duplicate players."""
+    db = SessionLocal()
+
+    try:
+        # Create test game
+        unique_id = str(uuid.uuid4())[:8].upper()
+        game = Game(
+            public_code=f"MERGE{unique_id}",
+            admin_code=f"ADM{unique_id}",
+            title=f"Merge Test Game {unique_id}"
+        )
+        db.add(game)
+        db.flush()
+
+        print(f"Created game: {game.public_code}")
+
+        # Create duplicate "Remy" players (case-sensitivity issue)
+        remy1 = Player(
+            display_name="Remy",
+            external_id="lw0lJXpCtc"  # lowercase 'c'
+        )
+        remy2 = Player(
+            display_name="REMY",
+            external_id="lw0lJXpCtC"  # uppercase 'C'
+        )
+        db.add(remy1)
+        db.add(remy2)
+        db.flush()
+
+        # Create duplicate "Trevor" players (different external_ids)
+        trevor1 = Player(
+            display_name="Trevor",
+            external_id="UxssJN_W8d"
+        )
+        trevor2 = Player(
+            display_name="Trevor",
+            external_id="_yJfKHdotT"
+        )
+        db.add(trevor1)
+        db.add(trevor2)
+        db.flush()
+
+        # Create another player (no duplicate)
+        alice = Player(
+            display_name="Alice",
+            external_id="alice123"
+        )
+        db.add(alice)
+        db.flush()
+
+        # Create sessions for old Remy (should be keeper - more sessions)
+        for i in range(5):
+            session = Session(
+                game_id=game.id,
+                external_id=f"session_remy1_{i}",
+                session_type="cash_game"
+            )
+            db.add(session)
+            db.flush()
+
+            summary = SessionPlayerSummary(
+                session_id=session.id,
+                player_id=remy1.id,
+                buy_in_sum=10000,
+                cash_out_sum=12000,
+                in_game=0,
+                net=2000,
+                names=["Remy"]
+            )
+            db.add(summary)
+
+        # Create 1 session for new Remy (should be merged)
+        session = Session(
+            game_id=game.id,
+            external_id="session_remy2_1",
+            session_type="cash_game"
+        )
+        db.add(session)
+        db.flush()
+
+        summary = SessionPlayerSummary(
+            session_id=session.id,
+            player_id=remy2.id,
+            buy_in_sum=10000,
+            cash_out_sum=8000,
+            in_game=0,
+            net=-2000,
+            names=["REMY"]
+        )
+        db.add(summary)
+
+        # Create sessions for old Trevor (should be keeper - more sessions)
+        for i in range(3):
+            session = Session(
+                game_id=game.id,
+                external_id=f"session_trevor1_{i}",
+                session_type="cash_game"
+            )
+            db.add(session)
+            db.flush()
+
+            summary = SessionPlayerSummary(
+                session_id=session.id,
+                player_id=trevor1.id,
+                buy_in_sum=10000,
+                cash_out_sum=11000,
+                in_game=0,
+                net=1000,
+                names=["Trevor"]
+            )
+            db.add(summary)
+
+        # Create 1 session for new Trevor (should be merged)
+        session = Session(
+            game_id=game.id,
+            external_id="session_trevor2_1",
+            session_type="cash_game"
+        )
+        db.add(session)
+        db.flush()
+
+        summary = SessionPlayerSummary(
+            session_id=session.id,
+            player_id=trevor2.id,
+            buy_in_sum=10000,
+            cash_out_sum=9000,
+            in_game=0,
+            net=-1000,
+            names=["Trevor"]
+        )
+        db.add(summary)
+
+        # Create session for Alice (no duplicates)
+        session = Session(
+            game_id=game.id,
+            external_id="session_alice_1",
+            session_type="cash_game"
+        )
+        db.add(session)
+        db.flush()
+
+        summary = SessionPlayerSummary(
+            session_id=session.id,
+            player_id=alice.id,
+            buy_in_sum=10000,
+            cash_out_sum=10500,
+            in_game=0,
+            net=500,
+            names=["Alice"]
+        )
+        db.add(summary)
+
+        db.commit()
+
+        print(f"\nTest data created successfully!")
+        print(f"\nDuplicate sets:")
+        print(f"  Remy: {remy1.id} (5 sessions) + {remy2.id} (1 session)")
+        print(f"  Trevor: {trevor1.id} (3 sessions) + {trevor2.id} (1 session)")
+        print(f"  Alice: {alice.id} (1 session) - no duplicates")
+        print(f"\nRun the merge script:")
+        print(f"  PYTHONPATH=src python merge_duplicate_players.py --game-code {game.public_code} --dry-run")
+
+        return game.public_code
+
+    except Exception as e:
+        db.rollback()
+        print(f"ERROR: {e}")
+        import traceback
+        traceback.print_exc()
+        return None
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    if not os.getenv("DATABASE_URL"):
+        print("ERROR: DATABASE_URL environment variable must be set")
+        print("Example: export DATABASE_URL=postgresql+psycopg2://user@127.0.0.1:5432/poker_analytics_test")
+        sys.exit(1)
+
+    create_test_data()


### PR DESCRIPTION

Fixes issue where PokerNow returns inconsistent capitalization for external_ids (e.g., "lw0lJXpCtc" vs "lw0lJXpCtC"), creating duplicate player records for the same person.

