### PR TITLE
fix: remove ended_at filter from balance history queries

### DIFF
--- a/backend/src/services/balance_history_service_v2.py
+++ b/backend/src/services/balance_history_service_v2.py
@@ -172,7 +172,6 @@ class BalanceHistoryServiceV2:
             JOIN sessions s ON sps.session_id = s.id
             WHERE sps.player_id = :player_id
               AND s.game_id = :game_id
-              AND s.ended_at IS NOT NULL
         """)
 
         poker_result = self.db.execute(
@@ -268,7 +267,6 @@ class BalanceHistoryServiceV2:
                 JOIN sessions s ON sps.session_id = s.id
                 WHERE sps.player_id = :player_id
                   AND s.game_id = :game_id
-                  AND s.ended_at IS NOT NULL
 
                 UNION ALL
 


### PR DESCRIPTION
Production issue: All 134 sessions have ended_at = NULL, causing balance history to show only payment transactions. Sessions are being filtered out by the 'WHERE ended_at IS NOT NULL' check.

Changes:
- Removed ended_at IS NOT NULL filter from poker_net_query (line 175)
- Removed ended_at IS NOT NULL filter from balance history query (line 271)