### PR TITLE
hotfix: handle NULL ended_at with COALESCE fallback

### DIFF
--- a/backend/src/services/balance_history_service_v2.py
+++ b/backend/src/services/balance_history_service_v2.py
@@ -255,7 +255,7 @@ class BalanceHistoryServiceV2:
                 -- Sessions
                 SELECT
                     sps.net / 100.0 AS amount,
-                    s.ended_at AS date,
+                    COALESCE(s.ended_at, s.started_at) AS date,
                     'session' AS type,
                     COALESCE(s.session_name, 'Session #' || s.game_number::text) AS description,
                     s.id::text AS session_id,


### PR DESCRIPTION
Production 500 error fix: Balance history was crashing because 134 sessions have ended_at = NULL. The query selected s.ended_at AS date, which returned NULL, causing AttributeError when calling .isoformat() on None.